### PR TITLE
Fix copyit-pandoc commands and documented it

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,7 +29,7 @@
 | =M-x copyit-pandoc-export-to-html=     | Convert and Copy file as HTML     |
 | =M-x copyit-pandoc-export-to-markdown= | Convert and Copy file as Markdown |
 
-=C-u M-x copyit-pandoc-export-to-html= and =C-u M-x copyit-pandoc-export-to-markdown= convert current buffer file.
+=C-u M-x copyit-pandoc-export-to-html= and =C-u M-x copyit-pandoc-export-to-markdown= convert a file.  When =C-u= is prepended, the content of the current buffer is converted.
 
 ** Customize
 *** =copyit-binary-file-copy-method= (default: =data-uri=)

--- a/copyit-pandoc.el
+++ b/copyit-pandoc.el
@@ -40,23 +40,23 @@
 (defun copyit-pandoc-export-to-html (file-path)
   "Convert and Copy `FILE-PATH' file as HTML."
   (interactive "p")
-  (cond
-   ((null file-path)
-    (setq file-path (read-file-name "")))
-   ((and (equal 4 file-path) buffer-file-name)
-    (setq file-path buffer-file-name)))
-  (kill-new (pandoc-convert-file file-path nil "html")))
+  (kill-new
+   (pandoc-convert-file
+    (if (and (eq 4 file-path) buffer-file-name)
+        buffer-file-name
+      (read-file-name ""))
+    nil "html")))
 
 ;;;###autoload
 (defun copyit-pandoc-export-to-markdown (file-path)
   "Convert and Copy `FILE-PATH' file as Markdown."
   (interactive "p")
-  (cond
-   ((null file-path)
-    (setq file-path (read-file-name "")))
-   ((and (equal 4 file-path) buffer-file-name)
-    (setq file-path buffer-file-name)))
-  (kill-new (pandoc-convert-file file-path nil (pandoc-markdown-dialect))))
+  (kill-new
+   (pandoc-convert-file
+    (if (and (eq 4 file-path) buffer-file-name)
+        buffer-file-name
+      (read-file-name ""))
+    nil (pandoc-markdown-dialect))))
 
 (provide 'copyit-pandoc)
 ;;; copyit-pandoc.el ends here


### PR DESCRIPTION
resolve https://github.com/zonuexe/emacs-copyit/issues/2

The usage of these commands was not consistent with other copyit commands.

From now on, as with the other copyit commands, a file is selected by default, and the contents of the current buffer are converted when prefixed with `C-u`.

Thank you @xbelanch!